### PR TITLE
feat: Update Keycloak secret handling in Kubernetes deployment

### DIFF
--- a/k8s/Containerfile
+++ b/k8s/Containerfile
@@ -13,7 +13,7 @@ COPY public ./public
 COPY src ./src
 COPY public ./public
 COPY tsconfig.json ./
-COPY .env.production ./.env
+#COPY .env.production ./.env
 
 # Install dependencies
 FROM base AS dependencies

--- a/k8s/service.yml
+++ b/k8s/service.yml
@@ -31,26 +31,11 @@ spec:
             - containerPort: 80
               protocol: TCP
           env:
-            - name: REACT_APP_KEYCLOAK_URL
-              valueFrom:
-                secretKeyRef:
-                  name: frontend-secrets
-                  key: keycloak-url
-            - name: REACT_APP_KEYCLOAK_CLIENT_ID
-              valueFrom:
-                secretKeyRef:
-                  name: frontend-secrets
-                  key: keycloak-client-id
-            - name: REACT_APP_KEYCLOAK_CLIENT_SECRET
+            - name: REACT_APP_KEYCLOAK_SECRET
               valueFrom:
                 secretKeyRef:
                   name: frontend-secrets
                   key: keycloak-client-secret
-            - name: REACT_APP_BACKEND_URL
-              valueFrom:
-                secretKeyRef:
-                  name: frontend-secrets
-                  key: backend-url
 ---
 apiVersion: v1
 kind: Service

--- a/src/app.config.tsx
+++ b/src/app.config.tsx
@@ -4,7 +4,7 @@ import {AuthProviderProps} from "react-oidc-context";
 export const oidcConfig = {
   authority: "https://keys.chewedfeed.com/realms/flags-gg",
   client_id: "dashboard",
-  client_secret: "uFBHtS1wJ9p5Epbw2wWHuBYVmK2tQzhc",
+  client_secret: process.env.REACT_APP_KEYCLOAK_SECRET,
   redirect_uri: window.location.origin,
   onSigninCallback: (_user: User | void) => {
     window.history.replaceState({}, document.title, window.location.pathname)


### PR DESCRIPTION
Update Kubernetes deployment file to use the REACT_APP_KEYCLOAK_SECRET
environment variable instead of individual secret keys for Keycloak
configuration. This improves security and simplifies the deployment setup.