### PR TITLE
fix: update output setting in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 1
       - name: Extract tag
         id: extract_tag
-        run: echo "::set-output name=tag::${GITHUB_REF/refs\/tags\//}"
+        run: echo "tag=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
       - name: Meta
         id: meta
         uses: docker/metadata-action@v4


### PR DESCRIPTION
Change the method of setting the output for the tag in the 
GitHub Actions workflow. The output is now set using the 
recommended approach of appending to the `$GITHUB_OUTPUT` 
file instead of using the deprecated `set-output` command. 
This ensures compatibility with future GitHub Actions 
updates and improves the reliability of the workflow.