### PR TITLE
feat(package.json): upgrade @flags-gg/react-library to v1.11.0

### DIFF
--- a/.github/workflows/pulls.yml
+++ b/.github/workflows/pulls.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4test
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
           fetch-depth: 1

--- a/.github/workflows/pulls.yml
+++ b/.github/workflows/pulls.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4test
         with:
           persist-credentials: false
           fetch-depth: 1

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -35,8 +35,8 @@ tasks:
         vars:
           COMMIT_HASH:
             sh: cat .commit_hash
-      - nerdctl push containers.chewed-k8s.net/{{.NAMESPACE}}/{{.SERVICE_NAME}}:{{.COMMIT_HASH}} --all-platforms
-      - nerdctl push containers.chewed-k8s.net/{{.NAMESPACE}}/{{.SERVICE_NAME}}:latest --all-platforms
+      - docker push containers.chewed-k8s.net/{{.NAMESPACE}}/{{.SERVICE_NAME}}:{{.COMMIT_HASH}} --all-platforms
+      - docker push containers.chewed-k8s.net/{{.NAMESPACE}}/{{.SERVICE_NAME}}:latest --all-platforms
     vars:
       COMMIT_HASH:
         sh: cat .commit_hash
@@ -46,7 +46,7 @@ tasks:
         vars:
           COMMIT_HASH:
             sh: cat .commit_hash
-      - nerdctl push containers.chewed-k8s.net/{{.NAMESPACE}}/{{.SERVICE_NAME}}:{{.COMMIT_HASH}} --all-platforms
+      - docker push containers.chewed-k8s.net/{{.NAMESPACE}}/{{.SERVICE_NAME}}:{{.COMMIT_HASH}} --all-platforms
     vars:
       COMMIT_HASH:
         sh: cat .commit_hash
@@ -57,9 +57,8 @@ tasks:
       - task: get-latest-tag
       - task: get-commit-hash
       - |
-        nerdctl build \
-          --platform=amd64,arm64 \
-          --tag containers.chewed-k8s.net/{{.NAMESPACE}}/{{.SERVICE_NAME}}:{{.COMMIT_HASH}} \
+        docker build \
+          --tag container1s.chewed-k8s.net/{{.NAMESPACE}}/{{.SERVICE_NAME}}:{{.COMMIT_HASH}} \
           --build-arg GIT_VERSION={{.LATEST_TAG}} \
           --build-arg GIT_BUILD={{.COMMIT_HASH}} \
           --build-arg SERVICE_NAME={{.SERVICE_NAME}} \
@@ -67,7 +66,7 @@ tasks:
           --build-arg FLAGS_AGENT_ID=a7978e82-bee0-4357-808d-53ee33d3bc55 \
           --build-arg FLAGS_ENVIRONMENT_ID=f8f84114-0706-40b7-a929-995d675f1f6d \
           -f ./k8s/Containerfile .
-      - nerdctl tag containers.chewed-k8s.net/{{.NAMESPACE}}/{{.SERVICE_NAME}}:{{.COMMIT_HASH}} containers.chewed-k8s.net/{{.NAMESPACE}}/{{.SERVICE_NAME}}:latest
+      - docker tag containers.chewed-k8s.net/{{.NAMESPACE}}/{{.SERVICE_NAME}}:{{.COMMIT_HASH}} containers.chewed-k8s.net/{{.NAMESPACE}}/{{.SERVICE_NAME}}:latest
     vars:
       LATEST_TAG:
         sh: cat .latest_tag
@@ -79,7 +78,7 @@ tasks:
       - task: get-latest-tag
       - task: get-commit-hash
       - |
-        nerdctl build \
+        docker build \
           --platform=amd64,arm64 \
           --tag containers.chewed-k8s.net/{{.NAMESPACE}}/{{.SERVICE_NAME}}:latest \
           --build-arg GIT_VERSION={{.LATEST_TAG}} \
@@ -89,7 +88,7 @@ tasks:
           --build-arg FLAGS_AGENT_ID=a7978e82-bee0-4357-808d-53ee33d3bc55 \
           --build-arg FLAGS_ENVIRONMENT_ID=f8f84114-0706-40b7-a929-995d675f1f6d \ 
           -f ./k8s/Containerfile .
-      - nerdctl push containers.chewed-k8s.net/{{.NAMESPACE}}/{{.SERVICE_NAME}}:latest --all-platforms
+      - docker push containers.chewed-k8s.net/{{.NAMESPACE}}/{{.SERVICE_NAME}}:latest --all-platforms
     vars:
       LATEST_TAG:
         sh: cat .latest_tag

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
-    "@flags-gg/react-library": "^1.10.0",
+    "@flags-gg/react-library": "^1.11.0",
     "@fontsource/roboto": "^5.2.5",
     "@mui/icons-material": "^5.16.14",
     "@mui/material": "^5.16.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^11.14.0
         version: 11.14.0(@emotion/react@11.14.0(@types/react@18.3.13)(react@18.3.1))(@types/react@18.3.13)(react@18.3.1)
       '@flags-gg/react-library':
-        specifier: ^1.10.0
-        version: 1.10.0(@types/react@18.3.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^1.11.0
+        version: 1.11.0(@types/react@18.3.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@fontsource/roboto':
         specifier: ^5.2.5
         version: 5.2.5
@@ -1179,8 +1179,8 @@ packages:
     resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  '@flags-gg/react-library@1.10.0':
-    resolution: {integrity: sha512-WHvybdhiQK3KZGa5k9TIJ3bxM3w/CG7STL45l3m45VyctKTFAEiRbxSRlg/3C0s4OgZS7TRln9iO054XkZ1ZDA==}
+  '@flags-gg/react-library@1.11.0':
+    resolution: {integrity: sha512-1BwNDN36oBXIMGoXi10QDL7oAPy6AqF51ISV+ZSm7ntEOFsnnDXfAP4/jL71v9CRa6JHrIiz0g6i4lM3fn4+2A==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -2609,8 +2609,8 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
-  lucide-react@0.471.2:
-    resolution: {integrity: sha512-A8fDycQxGeaSOTaI7Bm4fg8LBXO7Qr9ORAX47bDRvugCsjLIliugQO0PkKFoeAD57LIQwlWKd3NIQ3J7hYp84g==}
+  lucide-react@0.477.0:
+    resolution: {integrity: sha512-yCf7aYxerFZAbd8jHJxjwe1j7jEMPptjnaOqdYeirFnEy85cNR3/L+o0I875CYFYya+eEVzZSbNuRk8BZPDpVw==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -4528,11 +4528,11 @@ snapshots:
 
   '@eslint/js@8.57.1': {}
 
-  '@flags-gg/react-library@1.10.0(@types/react@18.3.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@flags-gg/react-library@1.11.0(@types/react@18.3.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       fast-equals: 5.2.2
       jotai: 2.12.1(@types/react@18.3.13)(react@18.3.1)
-      lucide-react: 0.471.2(react@18.3.1)
+      lucide-react: 0.477.0(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     transitivePeerDependencies:
@@ -6253,7 +6253,7 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
-  lucide-react@0.471.2(react@18.3.1):
+  lucide-react@0.477.0(react@18.3.1):
     dependencies:
       react: 18.3.1
 

--- a/src/Homepage/components/Pricing/index.tsx
+++ b/src/Homepage/components/Pricing/index.tsx
@@ -26,7 +26,7 @@ const Pricing: FC = () => {
   const [prices, setPrices] = useState<Price[]>([]);
 
   const getPricing = async () => {
-    const response = await fetch(`https://api.flags.gg/v1/pricing`);
+    const response = await fetch(`https://api.flags.gg/pricing`);
     const data = await response.json();
     return data;
   }


### PR DESCRIPTION
chore(Taskfile.yml): use docker instead of nerdctl
fix(Homepage/components/Pricing/index.tsx): update pricing API endpoint
refactor(Taskfile.yml): simplify docker build command
chore(pnpm-lock.yaml): update lucide-react dependency to v0.477.0
chore(.github/workflows/pulls.yml): use actions/checkout@v4test