### PR TITLE
feat: update @flags-gg/react-library to v1.11.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
-    "@flags-gg/react-library": "^1.11.0",
+    "@flags-gg/react-library": "^1.11.1",
     "@fontsource/roboto": "^5.2.5",
     "@mui/icons-material": "^5.16.14",
     "@mui/material": "^5.16.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^11.14.0
         version: 11.14.0(@emotion/react@11.14.0(@types/react@18.3.13)(react@18.3.1))(@types/react@18.3.13)(react@18.3.1)
       '@flags-gg/react-library':
-        specifier: ^1.11.0
-        version: 1.11.0(@types/react@18.3.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^1.11.1
+        version: 1.11.1(@types/react@18.3.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@fontsource/roboto':
         specifier: ^5.2.5
         version: 5.2.5
@@ -1179,8 +1179,8 @@ packages:
     resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  '@flags-gg/react-library@1.11.0':
-    resolution: {integrity: sha512-1BwNDN36oBXIMGoXi10QDL7oAPy6AqF51ISV+ZSm7ntEOFsnnDXfAP4/jL71v9CRa6JHrIiz0g6i4lM3fn4+2A==}
+  '@flags-gg/react-library@1.11.1':
+    resolution: {integrity: sha512-dxaFIKAB3ue7sn9U1X5j8SUBvA1A2pRSagheD3GEV/kZPOVIVvzb5TmtGcxrIFOlcQ4amVAn/NcNKt2M+j6gPw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -2609,8 +2609,8 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
-  lucide-react@0.477.0:
-    resolution: {integrity: sha512-yCf7aYxerFZAbd8jHJxjwe1j7jEMPptjnaOqdYeirFnEy85cNR3/L+o0I875CYFYya+eEVzZSbNuRk8BZPDpVw==}
+  lucide-react@0.479.0:
+    resolution: {integrity: sha512-aBhNnveRhorBOK7uA4gDjgaf+YlHMdMhQ/3cupk6exM10hWlEU+2QtWYOfhXhjAsmdb6LeKR+NZnow4UxRRiTQ==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -4528,11 +4528,11 @@ snapshots:
 
   '@eslint/js@8.57.1': {}
 
-  '@flags-gg/react-library@1.11.0(@types/react@18.3.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@flags-gg/react-library@1.11.1(@types/react@18.3.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       fast-equals: 5.2.2
       jotai: 2.12.2(@types/react@18.3.13)(react@18.3.1)
-      lucide-react: 0.477.0(react@18.3.1)
+      lucide-react: 0.479.0(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     transitivePeerDependencies:
@@ -6253,7 +6253,7 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
-  lucide-react@0.477.0(react@18.3.1):
+  lucide-react@0.479.0(react@18.3.1):
     dependencies:
       react: 18.3.1
 


### PR DESCRIPTION
Updates the @flags-gg/react-library dependency to version 1.11.1. This
update includes bug fixes and improvements to the library, enhancing the
overall functionality and stability of the application.